### PR TITLE
Add build context to Docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   expo-dev:
     image: io.ghcr.navneetkarnani.vscode-expo-starter
     build:
+      context: .
       dockerfile: ./Dockerfile
     volumes:
       - code:/root/workspace


### PR DESCRIPTION
Needed to fix docker-compose error which prevents this codespace to successfully build the container:
`The Compose file is invalid because: Service expo-dev has neither an image nor a build context specified. At least one must be provided.`